### PR TITLE
Use method routeMultipleLong instead of routeMultiple in order to avoid conflict with DebugEnhancer

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 HibernationFixup Changelog
 ============================
+#### v1.4.3
+- Use method routeMultipleLong instead of routeMultiple in order to avoid conflict with DebugEnhancer
+
 #### v1.4.2
 - Use method routeMultipleLong instead of routeMultiple in order to avoid conflict with future versions of CpuTscSync
 

--- a/HibernationFixup/kern_hbfx.cpp
+++ b/HibernationFixup/kern_hbfx.cpp
@@ -591,7 +591,7 @@ void HBFX::processKernel(KernelPatcher &patcher)
 
 		if (nvram_patches_required) {
 			KernelPatcher::RouteRequest request	{"_IOHibernateSystemSleep", IOHibernateSystemSleep, orgIOHibernateSystemSleep};
-			if (!patcher.routeMultiple(KernelPatcher::KernelID, &request, 1)) {
+			if (!patcher.routeMultipleLong(KernelPatcher::KernelID, &request, 1)) {
 				SYSLOG("HBFX", "patcher.routeMultiple for %s is failed with error %d", request.symbol, patcher.getError());
 				patcher.clearError();
 			}


### PR DESCRIPTION
`_IOHibernateSystemSleep` is routed in both plugins thus cause kp with "previous plugin had short jump type on a multiroute function, this is not allowed".