### PR TITLE
Auto hibernation: make sure auto-hibernation feature only happens when hibernatemode is set to 3. (Never when mode 0 or 25).

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,9 @@
 HibernationFixup Changelog
 ============================
 
+#### v1.5.0
+- Auto hibernation: make sure auto-hibernate feature only happens when hibernatemode is set to 3. (Never with mode 0 or 25).
+
 #### v1.4.9
 - Add macOS 14 (Sonoma) constants
 

--- a/HibernationFixup/kern_hbfx.cpp
+++ b/HibernationFixup/kern_hbfx.cpp
@@ -362,7 +362,7 @@ IOReturn HBFX::X86PlatformPlugin_sleepPolicyHandler(void * target, IOPMSystemSle
 	uint32_t standby_delay = 0;
 	bool pmset_default_mode = false;
 	auto autoHibernateMode = ADDPR(hbfx_config).autoHibernateMode;
-	while (callbackHBFX->isStandbyEnabled(standby_delay, pmset_default_mode) &&
+	while (callbackHBFX->isStandbyEnabled(standby_delay, pmset_default_mode) && pmset_default_mode &&
 		   (params->sleepType == kIOPMSleepTypeDeepIdle || params->sleepType == kIOPMSleepTypeStandby || params->sleepType == kIOPMSleepTypeNormalSleep))
 	{
 		IOPMPowerSource *power_source = callbackHBFX->getPowerSource();

--- a/HibernationFixup/kern_hbfx.cpp
+++ b/HibernationFixup/kern_hbfx.cpp
@@ -378,7 +378,7 @@ IOReturn HBFX::X86PlatformPlugin_sleepPolicyHandler(void * target, IOPMSystemSle
 				if (callbackHBFX->sleepPhase > kIOPMSleepPhase0)
 				{
 					callbackHBFX->sleepServiceWake = false;
-					if (pmset_default_mode && standby_delay != 0 && !callbackHBFX->wakeCalendarSet && callbackHBFX->sleepPhase > kIOPMSleepPhase0)
+					if (standby_delay != 0 && !callbackHBFX->wakeCalendarSet && callbackHBFX->sleepPhase > kIOPMSleepPhase0)
 						callbackHBFX->explicitlyCallSetMaintenanceWakeCalendar();
 				}
 				break;
@@ -389,7 +389,7 @@ IOReturn HBFX::X86PlatformPlugin_sleepPolicyHandler(void * target, IOPMSystemSle
 				if (callbackHBFX->sleepPhase > kIOPMSleepPhase0)
 				{
 					callbackHBFX->sleepServiceWake = false;
-					if (pmset_default_mode && standby_delay != 0 && !callbackHBFX->wakeCalendarSet && callbackHBFX->sleepPhase > kIOPMSleepPhase0)
+					if (standby_delay != 0 && !callbackHBFX->wakeCalendarSet && callbackHBFX->sleepPhase > kIOPMSleepPhase0)
 						callbackHBFX->explicitlyCallSetMaintenanceWakeCalendar();
 				}
 				break;
@@ -425,7 +425,7 @@ IOReturn HBFX::X86PlatformPlugin_sleepPolicyHandler(void * target, IOPMSystemSle
 			if (callbackHBFX->sleepPhase > kIOPMSleepPhase0)
 			{
 				callbackHBFX->sleepServiceWake = false;
-				if (pmset_default_mode && standby_delay != 0 && !callbackHBFX->wakeCalendarSet && callbackHBFX->sleepPhase > kIOPMSleepPhase0)
+				if (standby_delay != 0 && !callbackHBFX->wakeCalendarSet && callbackHBFX->sleepPhase > kIOPMSleepPhase0)
 					callbackHBFX->explicitlyCallSetMaintenanceWakeCalendar();
 			}
 			break;
@@ -433,7 +433,7 @@ IOReturn HBFX::X86PlatformPlugin_sleepPolicyHandler(void * target, IOPMSystemSle
 
 		if (callbackHBFX->sleepPhase > kIOPMSleepPhase0)
 		{
-			if (pmset_default_mode && standby_delay != 0 && !forceHibernate && !callbackHBFX->wakeCalendarSet && !callbackHBFX->sleepServiceWake)
+			if (standby_delay != 0 && !forceHibernate && !callbackHBFX->wakeCalendarSet && !callbackHBFX->sleepServiceWake)
 				callbackHBFX->explicitlyCallSetMaintenanceWakeCalendar();
 		}
 
@@ -445,7 +445,7 @@ IOReturn HBFX::X86PlatformPlugin_sleepPolicyHandler(void * target, IOPMSystemSle
 #endif
 		
 		bool doNotOverrideWakeUpTime = (ADDPR(hbfx_config).autoHibernateMode & Configuration::DoNotOverrideWakeUpTime);
-		bool setupHibernate = (forceHibernate || !callbackHBFX->wakeCalendarSet || callbackHBFX->sleepServiceWake || (pmset_default_mode && standby_delay == 0));
+		bool setupHibernate = (forceHibernate || !callbackHBFX->wakeCalendarSet || callbackHBFX->sleepServiceWake || standby_delay == 0);
 		if (setupHibernate && doNotOverrideWakeUpTime && !forceHibernate)
 		{
 			if (vars->standbyTimer != 0)


### PR DESCRIPTION
I'm a bit experimenting with `hbfx-ahbm | Number | 1` on my desktop build. Laptops have hibernatemode 3 by default.
Desktops have hibernatemode 0, which cause a S3 Sleep/Wake cycle. However I found that with standby / autopoweroff 1, auto-hibernation triggers. This also happens when I want to force hibernation using mode 25...

Since hbfx-ahbm's should be used when hibernatemode 3 ([https://applelife.ru/posts/670121/](https://applelife.ru/posts/670121/)), I've fixed all this behaviors by adding a simple check in the auto-hibernation logic.

Here are all the logs. (latest DEBUG build, and with the fix applied)

**pmset -g**

```
System-wide power settings:
Currently in use:
 standby              1
 Sleep On Power Button 1
 womp                 0
 hibernatefile        /var/vm/sleepimage
 powernap             0
 networkoversleep     0
 disksleep            10
 standbydelayhigh     660
 sleep                1
 autopoweroffdelay    1980
 hibernatemode        0
 autopoweroff         0
 ttyskeepawake        0
 displaysleep         10
 highstandbythreshold 50
 standbydelaylow      660
```

**sudo dmesg > dmesg_hib0_standby1.txt**
[dmesg_hib0_standby1.txt](https://github.com/acidanthera/HibernationFixup/files/14923538/dmesg_hib0_standby1.txt)

**log show --style syslog --last boot --predicate 'subsystem == "powerd" && category == "sleepWake" && (composedMessage CONTAINS " state due to" OR composedMessage CONTAINS " from ")' > log_SleepWake_hib0_standby1.txt**
[log_SleepWake_hib0_standby1.txt](https://github.com/acidanthera/HibernationFixup/files/14923551/log_SleepWake_hib0_standby1.txt)

```
hibernatemode 0
standby 0
autopoweroff 1
```
[dmesg_hib0_autopoweroff1.txt](https://github.com/acidanthera/HibernationFixup/files/14923653/dmesg_hib0_autopoweroff1.txt)
[log_SleepWake_hib0_autopoweroff1.txt](https://github.com/acidanthera/HibernationFixup/files/14923655/log_SleepWake_hib0_autopoweroff1.txt)

```
hibernatemode 25
standby 1
autopoweroff 0
```
[dmesg_hib25_standby1.txt](https://github.com/acidanthera/HibernationFixup/files/14923658/dmesg_hib25_standby1.txt)
[log_SleepWake_hib25_standby1.txt](https://github.com/acidanthera/HibernationFixup/files/14923662/log_SleepWake_hib25_standby1.txt)

Logs with the fix

[dmesg_hib25_standby1_fix.txt](https://github.com/acidanthera/HibernationFixup/files/14923667/dmesg_hib25_standby1_fix.txt)
[log_SleepWake_hib25_standby1_fix.txt](https://github.com/acidanthera/HibernationFixup/files/14923668/log_SleepWake_hib25_standby1_fix.txt)
[dmesg_hib0_standby1_fix.txt](https://github.com/acidanthera/HibernationFixup/files/14923669/dmesg_hib0_standby1_fix.txt)
[log_SleepWake_hib0_standby1_fix.txt](https://github.com/acidanthera/HibernationFixup/files/14923674/log_SleepWake_hib0_standby1_fix.txt)
[dmesg_hib0_autopoweroff1_fix.txt](https://github.com/acidanthera/HibernationFixup/files/14923675/dmesg_hib0_autopoweroff1_fix.txt)
[log_SleepWake_hib0_autopoweroff1_fix.txt](https://github.com/acidanthera/HibernationFixup/files/14923678/log_SleepWake_hib0_autopoweroff1_fix.txt)