### PR TITLE
patchPCIfamily: make sure it is enabled by default only on macOS Sier…

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 HibernationFixup Changelog
 ============================
+#### v1.5.3
+- patchPCIfamily: make sure it is enabled by default only on macOS Sierra 10.12.1 or later. Automatically disable it if runnning an older macOS version. The user can always disable this patch (if not needed) by using `-hbfx-disable-patch-pci` boot-arg or `hbfx-disable-patch-pci` NVRAM entry.
+- Improve readability of code & debug
+
 #### v1.5.2
 - Adapt code to make it work correclty in macOS Sequoia.
 

--- a/HibernationFixup/kern_config.hpp
+++ b/HibernationFixup/kern_config.hpp
@@ -19,8 +19,8 @@ public:
 	static const char *bootargDebug[];
 	static const char *bootargBeta[];
 	static constexpr const char *bootargDumpNvram         {"-hbfx-dump-nvram"};          // write NVRAM to file
-	static constexpr const char *bootargDisablePatchPCI   {"-hbfx-disable-patch-pci"};   // disable patch pci family
 	static constexpr const char *bootargPatchPCIWithList  {"hbfx-patch-pci"};            // patch pci family ignored device list
+	static constexpr const char *bootargDisablePatchPCI   {"-hbfx-disable-patch-pci"};   // disable patch pci family
 	static constexpr const char *bootargAutoHibernateMode {"hbfx-ahbm"};                 // auto hibernate mode
 
 public:

--- a/README.md
+++ b/README.md
@@ -17,14 +17,17 @@ IOHibernateRTCVariables from the system registry and writes it to NVRAM.
 - Enables 'native' hibernation on PC's with hardware NVRAM on 10.10.5 and later.
   'Native' means hibernation with encryption (standard hibernate modes 3 & 25)
 - Enables dumping NVRAM to file /nvram.plist before hibernation or panic
+- Enable patching IOPCIFamily in order to avoid hang & black screen after resume.
+  This patch is dynamic, it works only for hibernation and not for regular sleep.
+  It is automatically enabled in macOS Sierra 10.12.1 or later and disabled in older macOS versions.
 
 #### Boot-args
-- `-hbfx-dump-nvram` saves NVRAM to a file nvram.plist before hibernation and after kernel panic (with panic info)
-- `-hbfx-disable-patch-pci` disables patching of IOPCIFamily (this patch helps to avoid hang & black screen after resume (restoreMachineState won't be called for all devices)
-- `hbfx-patch-pci=XHC,IMEI,IGPU` allows to specify explicit device list (and restoreMachineState won't  be called only for these devices). Also supports values `none`, `false`, `off`.
+- `-hbfxoff` disables kext loading
 - `-hbfxdbg` turns on debugging output
 - `-hbfxbeta` enables loading on unsupported osx
-- `-hbfxoff` disables kext loading
+- `-hbfx-dump-nvram` saves NVRAM to a file nvram.plist before hibernation and after kernel panic (with panic info)
+- `hbfx-patch-pci=XHC,IMEI,IGPU` allows to specify explicit device list (and restoreMachineState won't be called only for these devices). Also supports values `none`, `false`, `off`.
+- `-hbfx-disable-patch-pci` disables patching of IOPCIFamily (this patch helps to avoid hang & black screen after resume (restoreMachineState won't be called for all devices))
 - `hbfx-ahbm=abhm_value` controls auto-hibernation feature, where abhm_value is an arithmetic sum of respective values below:
 	- `EnableAutoHibernation` = 1:
 		If this flag is set, system will hibernate instead of regular sleep (flags below can be used to limit this behavior)


### PR DESCRIPTION
…ra 10.12.1 or later. Automatically disable it if runnning an older macOS version. The user can always disable this patch (if not needed) by using `-hbfx-disable-patch-pci` boot-arg or `hbfx-disable-patch-pci` NVRAM.

As stated by @lvs1974 multiple times throughout last few years:
- https://applelife.ru/posts/624302
- https://applelife.ru/posts/655009
- https://applelife.ru/posts/676456

this patch is only needed on macOS 10.12.1 or later. Indeed I compared the Apple sources and found the difference:
- macOS 10.12: https://github.com/apple-oss-distributions/IOPCIFamily/blob/IOPCIFamily-284.1.3/IOPCIBridge.cpp#L1549
- macOS 10.12.1: https://github.com/apple-oss-distributions/IOPCIFamily/blob/IOPCIFamily-284.21.2/IOPCIBridge.cpp#L1544-L1554

I also made some minor improvements to code and debug in order to improve overall readability.


The only issue I found, is that I never get the debug log inside "IOPCIDevice_extendedConfigWrite16": https://github.com/acidanthera/HibernationFixup/blob/ed69b70/HibernationFixup/kern_hbfx.cpp#L597

I remember it was working until v1.2.0. Instructions by you here: https://applelife.ru/posts/672238

Here I attach my system debug log. Thanks
`$ sudo dmesg > dmesg_Darwin_16_1_0.txt`
[dmesg_Darwin_16_1_0.txt](https://github.com/user-attachments/files/19501380/dmesg_Darwin_16_1_0.txt)
